### PR TITLE
output roll call votes from roll call api call

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -216,7 +216,7 @@ class ApiController < ApplicationController
   
   def bill_roll_calls
     bills = Bill.find_all_by_id(params[:bill_id])
-    do_render(bills, :except => [:current_support_pb, :support_count_1, :rolls, :hot_bill_category_id, :support_count_2, :vote_count_2], :include => [:roll_calls])    
+    do_render(bills, :except => [:current_support_pb, :support_count_1, :rolls, :hot_bill_category_id, :support_count_2, :vote_count_2], :include => {:roll_calls => {:include => :roll_call_votes}})    
   end
   
   def issues

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -215,7 +215,7 @@ class ApiController < ApplicationController
   end
   
   def bill_roll_calls
-    bills = Bill.find_all_by_id(params[:bill_id])
+    bills = Bill.includes(:roll_calls => [:roll_call_votes]).find_all_by_id(params[:bill_id])
     do_render(bills, :except => [:current_support_pb, :support_count_1, :rolls, :hot_bill_category_id, :support_count_2, :vote_count_2], :include => {:roll_calls => {:include => :roll_call_votes}})    
   end
   


### PR DESCRIPTION
It is useful to include the roll call votes in the roll call api call. It does require another SQL query to be executed.    
