### PR TITLE
Minor adjustments needed to build and deploy from scratch

### DIFF
--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -9,8 +9,8 @@ namespace :deploy do
   desc "Hook up staging symlinks"
   task :symlinks do
     run "ln -s #{current_release}/public/robots.txt.staging #{current_release}/public/robots.txt"
-    run "mv #{current_release}/vendor/plugins/acts_as_solr/solr #{current_release}/vendor/plugins/acts_as_solr/solr-notused"
-    run "ln -s #{deploy_to}/#{shared_dir}/solr #{current_release}/vendor/plugins/acts_as_solr/solr"
+    #run "mv #{current_release}/vendor/plugins/acts_as_solr/solr #{current_release}/vendor/plugins/acts_as_solr/solr-notused"
+    #run "ln -s #{deploy_to}/#{shared_dir}/solr #{current_release}/vendor/plugins/acts_as_solr/solr"
   end
 end
 

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -12,6 +12,10 @@ namespace :deploy do
     #run "mv #{current_release}/vendor/plugins/acts_as_solr/solr #{current_release}/vendor/plugins/acts_as_solr/solr-notused"
     #run "ln -s #{deploy_to}/#{shared_dir}/solr #{current_release}/vendor/plugins/acts_as_solr/solr"
   end
+  
+  # NOOP for deploy:start and deploy:stop when using Passenger
+  task :start do ; end
+  task :stop  do ; end
 end
 
 after "deploy:update_code", "deploy:symlinks"


### PR DESCRIPTION
Eliminate some Capistrano Solr steps since Solr is no longer in use.

Ignore Capistrano deploy:start and deploy:stop because we're using Passenger. You may need to do something similar for deploy/production.rb also.
